### PR TITLE
Caddyfile disable encode

### DIFF
--- a/001_symfony7_wo_db/runtimes/007_frankenphp/frankenphp/Caddyfile
+++ b/001_symfony7_wo_db/runtimes/007_frankenphp/frankenphp/Caddyfile
@@ -30,7 +30,7 @@ http://localhost http://symfony7site {
 	}
 
 	root * public/
-	encode zstd gzip
+	#encode zstd gzip
 
 	# Uncomment the following lines to enable Mercure and Vulcain modules
 	#mercure {

--- a/001_symfony7_wo_db/runtimes/008_frankenphp_workermode/frankenphp/Caddyfile
+++ b/001_symfony7_wo_db/runtimes/008_frankenphp_workermode/frankenphp/Caddyfile
@@ -30,7 +30,7 @@ http://localhost http://symfony7site {
 	}
 
 	root * public/
-	encode zstd gzip
+	#encode zstd gzip
 
 	# Uncomment the following lines to enable Mercure and Vulcain modules
 	#mercure {


### PR DESCRIPTION
Disable extra step to encode the response.

Now Nginx and Unit, both don't encode the response.
And the throughput in Mb will be similar now.