### PR TITLE
Disable access and error log in nginx

### DIFF
--- a/001_symfony7_wo_db/runtimes/003_nginx_phpfpm/nginx/nginx.conf
+++ b/001_symfony7_wo_db/runtimes/003_nginx_phpfpm/nginx/nginx.conf
@@ -2,7 +2,7 @@
 user  nginx;
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log notice;
+error_log  stderr error;
 pid        /var/run/nginx.pid;
 
 
@@ -15,11 +15,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log  /var/log/nginx/access.log  main;
+    access_log  off;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/001_symfony7_wo_db/runtimes/006_nginx_roadrunner/nginx/nginx.conf
+++ b/001_symfony7_wo_db/runtimes/006_nginx_roadrunner/nginx/nginx.conf
@@ -2,7 +2,7 @@
 user  nginx;
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log notice;
+error_log  stderr error;
 pid        /var/run/nginx.pid;
 
 
@@ -15,11 +15,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log  /var/log/nginx/access.log  main;
+    access_log  off;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
Caddy and Unit by default don't create logs.

Write the logs is a blocking IO, and it's more affected with only 1 CPU.

issue #5