### PR TITLE
Nginx fastcgi_keep_conn on

### DIFF
--- a/001_symfony7_wo_db/runtimes/003_nginx_phpfpm/nginx/conf.d/symfony7site.conf
+++ b/001_symfony7_wo_db/runtimes/003_nginx_phpfpm/nginx/conf.d/symfony7site.conf
@@ -15,6 +15,7 @@ server {
     location ~ ^/index\.php(/|$) {
         # when PHP-FPM is configured to use TCP
         fastcgi_pass 003_phpfpm:9000;
+        fastcgi_keep_conn on;
 
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;

--- a/001_symfony7_wo_db/runtimes/006_nginx_roadrunner/nginx/conf.d/symfony7site.conf
+++ b/001_symfony7_wo_db/runtimes/006_nginx_roadrunner/nginx/conf.d/symfony7site.conf
@@ -8,6 +8,7 @@ server {
     location ~ ^/index\.php(/|$) {
         # when PHP-FPM is configured to use TCP
         fastcgi_pass 006_roadrunner:9000;
+        fastcgi_keep_conn on;
 
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;


### PR DESCRIPTION
_Nginx_ maintain compatibility with old FASTCGI servers.
Actually new servers use` keepalive` (Caddy, Unit, ...).

Without `fastcgi_keep_conn on` for each request _nginx_ need to create a new connection to `PHP-FPM`. And it's worst when the `PHP-FPM` server is in another server, like is the case in this benchmark.

Ideally it's better to use also keepalive connections in the upstream. Or use unix sockets in the same server.
But for now it's OK.  Later we'll check the PHP-FPM configuration.

![image](https://github.com/DimDev/php-runtimes-benchmark/assets/249085/cb7879fa-7da0-47f2-ade4-a25604e9004f)

